### PR TITLE
Float images on pages correctly

### DIFF
--- a/style.css
+++ b/style.css
@@ -286,3 +286,28 @@ body.scrolled.home .site-logo img {
 .has-small-font-size {
   line-height: var(--line-height-s--font-family-tertiary);
 }
+
+/* Adds to styles set in */
+/* ../planet4-master-theme/assets/src/scss/pages/post/_article-content.scss */
+.page-content .alignright,
+.page-content .alignleft {
+  @media (min-width: 576px) {
+      padding-top: 6px;
+      max-width: 100%;
+  }
+}
+
+.page-content .alignright {
+  @media (min-width: 576px) {
+      float: right;
+      margin: 0 0 space(1) space(1);
+  }
+}
+
+.page-content .alignleft {
+  @media (min-width: 576px) {
+      float: left;
+      margin: 0 space(1) space(1) 0;
+  }
+
+}


### PR DESCRIPTION
# Pull Request Overview
This PR applies the same styles that exist in the base theme for left/right floated images on posts, to pages. 

In doing that, it fixes [this bug](https://www.notion.so/greenpeaceaustraliapacific/P4-Float-images-correctly-9ca9b50751554a06a26b746b1bbcdf43?pvs=4)

# 📷 Screenshots
![image](https://github.com/greenpeace/planet4-child-theme-australiapacific/assets/13824257/fdc6a478-ec9d-4325-91cc-c8fd460b6068)
