### PR TITLE
Fix rounded images again

### DIFF
--- a/style.css
+++ b/style.css
@@ -78,11 +78,11 @@ h3,
 
 /* SEE: planet4/plugins/planet4-plugin-gutenberg-blocks/assets/src/styles/blocks/core-overrides/Image.scss */
 
-.wp-block-image .is-style-rounded-180 img {
+.wp-block-image.is-style-rounded-180 img {
     max-width: 180px;
   }
 
-.wp-block-image .is-style-rounded-90 img {
+.wp-block-image.is-style-rounded-90 img {
     max-width: 90px;
   }
 

--- a/style/global.scss
+++ b/style/global.scss
@@ -58,11 +58,11 @@ h6 {
 
 /* SEE: planet4/plugins/planet4-plugin-gutenberg-blocks/assets/src/styles/blocks/core-overrides/Image.scss */
 .wp-block-image {
-  .is-style-rounded-180 img {
+  &.is-style-rounded-180 img {
     max-width: 180px;
   }
 
-  .is-style-rounded-90 img {
+  &.is-style-rounded-90 img {
     max-width: 90px;
   }
 }


### PR DESCRIPTION
# Pull Request Overview
When I converted to SASS, I forgot that styles should have been applied to `.wp-block-image.is-style-rounded-180` instead of `.wp-block-image .is-style-rounded-180`. This fixes that.

# 📷 Screenshots
<!-- 🎥 Show off your work if you want! -->
<!-- 😀 No worries if this doesn't apply though.  -->

## 🤨 Any Issues or Questions?
<!-- Use this area to document any specific questions or areas of concern for the Reviewers -->

Contributor checklist:
- [ ] Reference a GitHub issue, Jira ticket, or Notion card in the description 💯
- [ ] 📝 Update the CHANGELOG.md (Put under `[Unreleased]`). Include link to this PR.
- [ ] 📝 Add JSDoc code documentation
- [ ] 🏷 Add flow types. (If needed.)
- [ ] ✅ Add unit tests (`*.test.js`) and/or Cypress Tests.
- [ ] 📖 Create Storybook stories. (For any applicable Components.)
- [ ] 📸 Update snapshots.  Run `yarn test:watch`, press 'a' for "all tests", and "u" to update snaps if needed.
- [ ] Run tests (`yarn test` and `yarn flow`) and clean up any errors 🚀
- [x] Select 1-2 Reviewers
- [x] Feel good about yourself, you're doing great! 🥳
