### PR TITLE
Update style.css for cookie-notice z-index

### DIFF
--- a/style.css
+++ b/style.css
@@ -446,3 +446,9 @@ a.wp-block-social-link-anchor::after {
 .full-excerpt .posts-list-query .wp-block-post-excerpt__excerpt {
   -webkit-line-clamp: 10 !important;
 }
+
+/* Sets the cookies block above Optimonk sticky footers which have a z-index: 2147483646  */
+
+.cookie-notice {
+z-index: 3000000000;
+}


### PR DESCRIPTION
Sets the cookies block to site above Optimonk sticky footers which have a z-index: 2147483646

# Pull Request Overview

We are using sticky footers on the website during the EOFY campaign. Currently the Optimonk sticky footer has a z-index of 2147483646. The .cookie-notice has a z-index of 100. We need to make the cookie block sit on top of the Optimonk footer. I have discussed with Optimonk support and there isn't a way to change the z-index on sticky footer. Therefore we need to change it on the .cookie-notice. 

# 📷 Screenshots

Before:
<img width="1071" alt="Screenshot 2024-05-23 at 10 23 54 AM" src="https://github.com/greenpeace/planet4-child-theme-australiapacific/assets/107445567/a09807dd-dcf1-42b9-bec7-2d7680f0ec58">


After:
<img width="1067" alt="Screenshot 2024-05-23 at 10 23 30 AM" src="https://github.com/greenpeace/planet4-child-theme-australiapacific/assets/107445567/7592a8a6-4ebe-4c53-b73c-4723c6e98e6c">



## 🤨 Any Issues or Questions?
<!-- Use this area to document any specific questions or areas of concern for the Reviewers -->

## 🏁 PR Checklist

<!-- Get your PR across the finish line with these tips! -->
<!-- 🎨 Fun tip: add emoji to your git commits with https://gitmoji.carloscuesta.me/ -->

Reviewer checklist:
- [ ] ✨ This PR includes new user-facing feature and/or settings
- [ ] 📝 Documentation for new features/settings are in PR description (to go to wiki or Coral docs) 

Contributor checklist:
- [ ] Reference a GitHub issue, Jira ticket, or Notion card in the description 💯
- [ ] 📝 Update the CHANGELOG.md (Put under `[Unreleased]`). Include link to this PR.
- [ ] 📝 Add JSDoc code documentation
- [ ] 🏷 Add flow types. (If needed.)
- [ ] ✅ Add unit tests (`*.test.js`) and/or Cypress Tests.
- [ ] 📖 Create Storybook stories. (For any applicable Components.)
- [ ] 📸 Update snapshots.  Run `yarn test:watch`, press 'a' for "all tests", and "u" to update snaps if needed.
- [ ] Run tests (`yarn test` and `yarn flow`) and clean up any errors 🚀
- [ ] Select 1-2 Reviewers
- [x] Feel good about yourself, you're doing great! 🥳
