### PR TITLE
Fix share buttons props from single page

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -93,7 +93,11 @@
                         {% endif %}
                     </div>
                 </div>
-                {% include "blocks/share_buttons.twig" with {social:post.share_meta, utm_medium: 'share'} %}
+                {% include "blocks/share_buttons.twig" with {
+                    social: post.share_meta,
+                    utm_medium: 'share',
+                    share_platforms: post.social_share_platforms,
+                } %}
 
                 <!-- Include archive block-->
                 {% if 'archive' in post.tags|map(attribute => attribute.slug) %}


### PR DESCRIPTION
# Description
Include the missing `share_platforms` prop.

## Testing
The social share buttons might be included in all posts.