### PR TITLE
fix: Remove whitespace under bottom navigation

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,7 +102,7 @@ nav * {
 
 @media (min-width: 768px) {
   .footer-cta {
-    margin-bottom: -100px !important;
+    margin-bottom: -170px !important;
     padding-bottom: 180px !important;
   }
 }

--- a/style/global.scss
+++ b/style/global.scss
@@ -76,7 +76,7 @@ nav * {
 
 @media (min-width: $medium-width) {
   .footer-cta {
-    margin-bottom: -100px !important;
+    margin-bottom: -170px !important;
     padding-bottom: 180px !important;
   }
 }


### PR DESCRIPTION


# Pull Request Overview
The bottom navigation was pushing the footer down too far, so I've expanded the negative margin down the bottom to fix the gap

Fixes https://www.notion.so/greenpeaceaustraliapacific/P4-The-quick-links-page-layout-has-been-impacted-by-a-P4-update-184cd2add9ba81968438f8b662561d78?source=copy_link

# 📷 Screenshots

## Before
![image](https://github.com/user-attachments/assets/4fb6c8a2-c1c3-45de-8057-bdf2babaf9c8)


## After
![image](https://github.com/user-attachments/assets/fc049214-2233-4f74-a54c-315941bf35e9)

## 🏁 PR Checklist

<!-- Get your PR across the finish line with these tips! -->
<!-- 🎨 Fun tip: add emoji to your git commits with https://gitmoji.carloscuesta.me/ -->

Reviewer checklist:
- [ ] ✨ This PR is an enhancement (new features etc)
- [ ] 🐛 This PR fixes a bug
- [ ] 📝 Documentation was needed and has been updated in Notion -> P4-Planet-4-Technical-Documentation   

Contributor checklist:
- [x] 🎨 I have **not** _directly_ edited the `.css` source styles (edit the `.scss` source files, then run `npm run build-theme-css` if you need to edit styles!)
- [x] Reference a GitHub issue or Notion card in the description 💯
- [x] Select 1-2 Reviewers
- [x] Feel good about yourself, you're doing great! 🥳

